### PR TITLE
feat: migrate from HashiCorp Vault to OpenBao with PostgreSQL backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,16 @@
+# OpenBao Configuration
+OPENBAO_ADDR=http://localhost:8200
+OPENBAO_TOKEN=dev-only-token
+
+# PostgreSQL Configuration (for OpenBao backend)
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=openbao
+POSTGRES_USER=openbao
+POSTGRES_PASSWORD=openbao_password
+
+# Example secret variables
 DB_URL=postgresql://user:password@localhost:5432/mydb
 EXTERNAL_API_KEY=sk-your-api-key-here
 DEBUG=true
+SECRET_TOKEN=your_secret_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
+
+# Openbao
+unseal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`envoi` is a CLI tool for environment-agnostic configuration orchestration. It provides a single source of truth (`envoi.yml`) for managing environment variables across different environments (local, staging, production) with support for multiple providers like `.env` files and HashiCorp Vault.
+`envoi` is a CLI tool for environment-agnostic configuration orchestration. It provides a single source of truth (`envoi.yml`) for managing environment variables across different environments (local, staging, production) with support for multiple providers like `.env` files, HashiCorp Vault, and OpenBao.
 
 ## Common Commands
 
@@ -71,6 +71,7 @@ Use `--verbose` flag to see detailed debug information with colored output.
 **Provider System** (`src/providers/`):
 - `local.ts`: Reads variables from `.env` files using dotenv
 - `vault.ts`: Integrates with HashiCorp Vault for secret management
+- `openbao.ts`: Integrates with OpenBao for secret management
 - `registry.ts`: Registry pattern for extensible provider system
 
 **Core Engine** (`src/core/`):
@@ -85,15 +86,16 @@ Use `--verbose` flag to see detailed debug information with colored output.
 
 ### Key Design Patterns
 
-**Provider Registry**: Extensible system for adding new providers (local, vault, etc.)
+**Provider Registry**: Extensible system for adding new providers (local, vault, openbao, etc.)
 **Resolution Priority**: Variables resolve in order: existing env → configured sources → defaults
 **Security**: No secret caching - variables loaded directly into subprocess environment
 **Validation**: Zod schema validation ensures configuration integrity
+**Provider Configuration**: Optional providers object for enabling/disabling specific providers
 
 ### Environment Variable Resolution Flow
 
 1. Check if variable already exists in `process.env`
-2. If not found, resolve from configured sources (`.env`, Vault)
+2. If not found, resolve from configured sources (`.env`, Vault, OpenBao)
 3. If still not found, use default value from `envoi.yml`
 4. If required and no value found, throw validation error
 
@@ -111,7 +113,8 @@ interface Provider {
 
 `envoi.yml` defines:
 - `variables`: Array of variable definitions with metadata
-- `sources`: Mapping of variable names to provider configurations
+- `sources`: Mapping of variable names to provider configurations (legacy format)
+- `providers`: Optional provider configuration object for enabling/disabling providers
 - `command`: Optional default command configuration with override capability
 
 ### Command Configuration
@@ -155,6 +158,57 @@ sources:
     type: vault
     path: secret/data/myapp
     key: api_token
+  API_KEY:
+    type: openbao
+    path: secret/data/myapp
+    key: api_key
+```
+
+### New Provider Configuration (Recommended)
+
+The new provider configuration allows you to enable/disable specific providers:
+
+```yaml
+providers:
+  local:
+    type: local
+    enabled: true
+    config:
+      file: .env
+  
+  openbao:
+    type: openbao
+    enabled: true
+    config:
+      address: "http://localhost:8200"
+      token: "${OPENBAO_TOKEN}"
+
+# Sources configuration (still supported for backward compatibility)
+sources:
+  DATABASE_URL:
+    type: local
+    file: .env
+    key: DB_URL
+  SECRET_TOKEN:
+    type: openbao
+    path: secret/data/myapp
+    key: secret_token
+```
+
+### OpenBao Setup with Docker
+
+For local development, you can use the provided Docker Compose setup:
+
+```bash
+# Start OpenBao and PostgreSQL
+docker-compose up -d
+
+# Verify OpenBao is running
+curl http://localhost:8200/v1/sys/health
+
+# Set environment variables
+export OPENBAO_ADDR=http://localhost:8200
+export OPENBAO_TOKEN=dev-only-token
 ```
 
 ## Error Handling
@@ -168,7 +222,8 @@ Custom error classes provide clear feedback:
 
 Tests in `__tests__/` cover:
 - Configuration loading and validation
-- Provider functionality (local, vault)
+- Provider functionality (local, vault, openbao)
 - Variable resolution logic
+- Provider configuration system
 
 Test setup includes provider registration via `providerRegistry` to ensure isolation from main CLI initialization.

--- a/__tests__/dynamic-registration.test.ts
+++ b/__tests__/dynamic-registration.test.ts
@@ -1,0 +1,90 @@
+import { registerProvidersFromConfig } from '../src/providers/dynamic-registration';
+import { providerRegistry } from '../src/providers/registry';
+import { EnvoiConfig } from '../src/types';
+
+// Mock the OpenBao provider to avoid node-fetch import issues
+jest.mock('../src/providers/openbao', () => ({
+  OpenBaoProvider: jest.fn().mockImplementation(() => ({
+    name: 'openbao',
+    resolve: jest.fn()
+  }))
+}));
+
+describe('Dynamic Provider Registration', () => {
+  beforeEach(() => {
+    providerRegistry.clear();
+  });
+
+  test('should register local provider by default when no providers config', () => {
+    const config: EnvoiConfig = {
+      variables: [],
+    };
+
+    registerProvidersFromConfig(config);
+
+    expect(providerRegistry.has('local')).toBe(true);
+    expect(providerRegistry.getRegisteredProviders()).toContain('local');
+  });
+
+  test('should register enabled providers from config', () => {
+    const config: EnvoiConfig = {
+      variables: [],
+      providers: {
+        local: {
+          type: 'local',
+          enabled: true,
+          config: { file: '.env' }
+        }
+      }
+    };
+
+    registerProvidersFromConfig(config);
+
+    expect(providerRegistry.has('local')).toBe(true);
+    expect(providerRegistry.getRegisteredProviders()).toEqual(['local']);
+  });
+
+  test('should skip disabled providers', () => {
+    const config: EnvoiConfig = {
+      variables: [],
+      providers: {
+        local: {
+          type: 'local',
+          enabled: true,
+          config: { file: '.env' }
+        },
+        vault: {
+          type: 'vault',
+          enabled: false,
+          config: { address: 'http://localhost:8200' }
+        }
+      }
+    };
+
+    registerProvidersFromConfig(config);
+
+    expect(providerRegistry.has('local')).toBe(true);
+    expect(providerRegistry.has('vault')).toBe(false);
+    expect(providerRegistry.getRegisteredProviders()).toEqual(['local']);
+  });
+
+  test('should handle provider creation errors gracefully', () => {
+    const config: EnvoiConfig = {
+      variables: [],
+      providers: {
+        invalid: {
+          type: 'invalid' as any,
+          enabled: true,
+          config: {}
+        }
+      }
+    };
+
+    // Should not throw, but should log warning
+    expect(() => {
+      registerProvidersFromConfig(config);
+    }).not.toThrow();
+
+    expect(providerRegistry.isEmpty()).toBe(true);
+  });
+});

--- a/__tests__/local-provider.test.ts
+++ b/__tests__/local-provider.test.ts
@@ -4,8 +4,11 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 describe('LocalProvider', () => {
-  const provider = new LocalProvider();
   const testEnvPath = path.join(__dirname, 'test-local.env');
+  
+  const createProvider = (configFile?: string) => {
+    return new LocalProvider(configFile ? { file: configFile } : { file: '.env' });
+  };
 
   beforeEach(async () => {
     await fs.writeFile(testEnvPath, 'TEST_KEY=test_value\nANOTHER_KEY=another_value');
@@ -20,6 +23,7 @@ describe('LocalProvider', () => {
   });
 
   test('should resolve variable from .env file', async () => {
+    const provider = createProvider();
     const source: VariableSource = {
       type: 'local',
       file: testEnvPath,
@@ -31,6 +35,7 @@ describe('LocalProvider', () => {
   });
 
   test('should throw error for non-existent file', async () => {
+    const provider = createProvider();
     const source: VariableSource = {
       type: 'local',
       file: 'non-existent.env',
@@ -43,6 +48,7 @@ describe('LocalProvider', () => {
   });
 
   test('should throw error for missing key', async () => {
+    const provider = createProvider();
     const source: VariableSource = {
       type: 'local',
       file: testEnvPath,
@@ -55,6 +61,7 @@ describe('LocalProvider', () => {
   });
 
   test('should throw error for non-local source type', async () => {
+    const provider = createProvider();
     const source: VariableSource = {
       type: 'vault',
       key: 'TEST_KEY'
@@ -62,17 +69,6 @@ describe('LocalProvider', () => {
 
     await expect(provider.resolve(source)).rejects.toThrow(
       'LocalProvider cannot handle source type: vault'
-    );
-  });
-
-  test('should throw error when file is not specified', async () => {
-    const source: VariableSource = {
-      type: 'local',
-      key: 'TEST_KEY'
-    };
-
-    await expect(provider.resolve(source)).rejects.toThrow(
-      'Local provider requires a "file" specification'
     );
   });
 });

--- a/__tests__/openbao-config.test.ts
+++ b/__tests__/openbao-config.test.ts
@@ -1,0 +1,136 @@
+import { validateConfig } from '../src/config/schema';
+
+describe('OpenBao Configuration Integration', () => {
+  test('should validate configuration with OpenBao provider', () => {
+    const configData = {
+      variables: [
+        {
+          name: 'SECRET_KEY',
+          required: true,
+          description: 'Secret key from OpenBao'
+        }
+      ],
+      sources: {
+        SECRET_KEY: {
+          type: 'openbao',
+          path: 'secret/data/myapp',
+          key: 'secret_key'
+        }
+      }
+    };
+
+    const config = validateConfig(configData);
+    expect(config.variables).toHaveLength(1);
+    expect(config.sources?.SECRET_KEY).toBeDefined();
+    expect(config.sources?.SECRET_KEY.type).toBe('openbao');
+  });
+
+  test('should validate configuration with new provider format', () => {
+    const configData = {
+      variables: [
+        {
+          name: 'SECRET_KEY',
+          required: true,
+          description: 'Secret key from OpenBao'
+        }
+      ],
+      providers: {
+        openbao: {
+          type: 'openbao',
+          enabled: true,
+          config: {
+            address: 'http://localhost:8200',
+            token: '${OPENBAO_TOKEN}'
+          }
+        }
+      },
+      sources: {
+        SECRET_KEY: {
+          type: 'openbao',
+          path: 'secret/data/myapp',
+          key: 'secret_key'
+        }
+      }
+    };
+
+    const config = validateConfig(configData);
+    expect(config.providers?.openbao).toBeDefined();
+    expect(config.providers?.openbao.type).toBe('openbao');
+    expect(config.providers?.openbao.enabled).toBe(true);
+  });
+
+  test('should handle backward compatibility with Vault and OpenBao', () => {
+    const configData = {
+      variables: [
+        {
+          name: 'OLD_SECRET',
+          required: true,
+          description: 'Secret from Vault'
+        },
+        {
+          name: 'NEW_SECRET',
+          required: true,
+          description: 'Secret from OpenBao'
+        }
+      ],
+      sources: {
+        OLD_SECRET: {
+          type: 'vault',
+          path: 'secret/data/myapp',
+          key: 'old_secret'
+        },
+        NEW_SECRET: {
+          type: 'openbao',
+          path: 'secret/data/myapp',
+          key: 'new_secret'
+        }
+      }
+    };
+
+    const config = validateConfig(configData);
+    expect(config.sources).toBeDefined();
+    expect(config.sources?.OLD_SECRET.type).toBe('vault');
+    expect(config.sources?.NEW_SECRET.type).toBe('openbao');
+  });
+
+  test('should reject invalid provider type', () => {
+    const configData = {
+      variables: [
+        {
+          name: 'SECRET_KEY',
+          required: true,
+          description: 'Secret key'
+        }
+      ],
+      sources: {
+        SECRET_KEY: {
+          type: 'invalid_provider' as any,
+          path: 'secret/data/myapp',
+          key: 'secret_key'
+        }
+      }
+    };
+
+    expect(() => validateConfig(configData)).toThrow();
+  });
+
+  test('should reject invalid provider configuration', () => {
+    const configData = {
+      variables: [
+        {
+          name: 'SECRET_KEY',
+          required: true,
+          description: 'Secret key'
+        }
+      ],
+      providers: {
+        openbao: {
+          type: 'invalid_provider' as any,
+          enabled: true
+        }
+      }
+    };
+
+    expect(() => validateConfig(configData)).toThrow();
+  });
+});

--- a/__tests__/openbao-provider.test.ts
+++ b/__tests__/openbao-provider.test.ts
@@ -1,0 +1,282 @@
+import { OpenBaoProvider } from '../src/providers/openbao';
+import { VariableSource } from '../src/types';
+
+// Mock node-fetch at the module level
+jest.mock('node-fetch', () => jest.fn());
+
+// Import the mocked module
+import fetch from 'node-fetch';
+const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+// Mock Response class
+class MockResponse {
+  constructor(
+    public ok: boolean,
+    public status: number,
+    public statusText: string,
+    private jsonData: any
+  ) {}
+
+  async json() {
+    return this.jsonData;
+  }
+}
+
+describe('OpenBaoProvider', () => {
+  let provider: OpenBaoProvider;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset environment variables
+    process.env = { ...originalEnv };
+    process.env.OPENBAO_TOKEN = 'test-token';
+    
+    // Reset all mocks
+    jest.clearAllMocks();
+    
+    // Create new provider instance
+    provider = new OpenBaoProvider();
+  });
+
+  afterEach(() => {
+    // Restore original environment variables
+    process.env = originalEnv;
+  });
+
+  test('should initialize with default address', () => {
+    delete process.env.OPENBAO_ADDR;
+    const provider = new OpenBaoProvider();
+    expect(provider).toBeDefined();
+  });
+
+  test('should initialize with custom address', () => {
+    process.env.OPENBAO_ADDR = 'http://custom:8200';
+    const provider = new OpenBaoProvider();
+    expect(provider).toBeDefined();
+  });
+
+  test('should throw error when token is missing', () => {
+    delete process.env.OPENBAO_TOKEN;
+    expect(() => new OpenBaoProvider()).toThrow(
+      'OPENBAO_TOKEN environment variable is required for OpenBao provider'
+    );
+  });
+
+  test('should resolve variable from OpenBao', async () => {
+    const mockResponse = {
+      data: {
+        data: {
+          secret_key: 'secret_value'
+        }
+      }
+    };
+
+    mockedFetch.mockResolvedValueOnce(new MockResponse(true, 200, 'OK', mockResponse) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    const value = await provider.resolve(source);
+    expect(value).toBe('secret_value');
+    
+    expect(mockedFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:8200/v1/secret/data/myapp',
+      {
+        method: 'GET',
+        headers: {
+          'X-Vault-Token': 'test-token',
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  });
+
+  test('should handle custom OpenBao address', async () => {
+    process.env.OPENBAO_ADDR = 'http://custom:8200';
+    const provider = new OpenBaoProvider();
+    
+    const mockResponse = {
+      data: {
+        data: {
+          secret_key: 'secret_value'
+        }
+      }
+    };
+
+    mockedFetch.mockResolvedValueOnce(new MockResponse(true, 200, 'OK', mockResponse) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await provider.resolve(source);
+    
+    expect(mockedFetch).toHaveBeenCalledWith(
+      'http://custom:8200/v1/secret/data/myapp',
+      expect.any(Object)
+    );
+  });
+
+  test('should throw error for non-openbao source type', async () => {
+    const source: VariableSource = {
+      type: 'vault',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    } as any;
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'OpenBaoProvider cannot handle source type: vault'
+    );
+  });
+
+  test('should throw error when path is missing', async () => {
+    const source: VariableSource = {
+      type: 'openbao',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'OpenBao provider requires a "path" specification'
+    );
+  });
+
+  test('should throw error when key is missing', async () => {
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'OpenBao provider requires a "key" specification'
+    );
+  });
+
+  test('should throw error for HTTP error response', async () => {
+    mockedFetch.mockResolvedValueOnce(new MockResponse(false, 404, 'Not Found', null) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'OpenBao API request failed: 404 Not Found'
+    );
+  });
+
+  test('should throw error for missing secret data', async () => {
+    const mockResponse = {
+      data: {
+        data: {}
+      }
+    };
+
+    mockedFetch.mockResolvedValueOnce(new MockResponse(true, 200, 'OK', mockResponse) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'missing_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'Key "missing_key" not found in OpenBao secret at path: secret/data/myapp'
+    );
+  });
+
+  test('should throw error for null value', async () => {
+    const mockResponse = {
+      data: {
+        data: {
+          secret_key: null
+        }
+      }
+    };
+
+    mockedFetch.mockResolvedValueOnce(new MockResponse(true, 200, 'OK', mockResponse) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'Key "secret_key" not found in OpenBao secret at path: secret/data/myapp'
+    );
+  });
+
+  test('should throw error for non-string value', async () => {
+    const mockResponse = {
+      data: {
+        data: {
+          secret_key: 123
+        }
+      }
+    };
+
+    mockedFetch.mockResolvedValueOnce(new MockResponse(true, 200, 'OK', mockResponse) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'Expected string value for key "secret_key", but got number'
+    );
+  });
+
+  test('should handle network errors', async () => {
+    mockedFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'Failed to read from OpenBao at secret/data/myapp: Network error'
+    );
+  });
+
+  test('should handle invalid JSON response', async () => {
+    const badResponse = new MockResponse(true, 200, 'OK', null);
+    jest.spyOn(badResponse, 'json').mockRejectedValue(new Error('Invalid JSON'));
+    mockedFetch.mockResolvedValueOnce(badResponse as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'Failed to read from OpenBao at secret/data/myapp: Invalid JSON'
+    );
+  });
+
+  test('should handle missing response data', async () => {
+    const mockResponse = {};
+
+    mockedFetch.mockResolvedValueOnce(new MockResponse(true, 200, 'OK', mockResponse) as any);
+
+    const source: VariableSource = {
+      type: 'openbao',
+      path: 'secret/data/myapp',
+      key: 'secret_key'
+    };
+
+    await expect(provider.resolve(source)).rejects.toThrow(
+      'No data found at OpenBao path: secret/data/myapp'
+    );
+  });
+});

--- a/__tests__/provider-filtering.test.ts
+++ b/__tests__/provider-filtering.test.ts
@@ -1,0 +1,122 @@
+import { filterDisabledProviders } from '../src/utils/provider-filter';
+import { EnvoiConfig } from '../src/types';
+import { providerRegistry } from '../src/providers/registry';
+
+describe('Provider Filtering', () => {
+  beforeEach(() => {
+    providerRegistry.clear();
+    // Register a mock provider for testing
+    providerRegistry.register({
+      name: 'local',
+      resolve: jest.fn()
+    });
+  });
+
+  test('should filter out variables that use disabled providers', () => {
+    const config: EnvoiConfig = {
+      variables: [
+        { name: 'LOCAL_VAR', required: false, description: 'Local variable' },
+        { name: 'VAULT_VAR', required: false, description: 'Vault variable' },
+        { name: 'OPENBAO_VAR', required: false, description: 'OpenBao variable' },
+      ],
+      sources: {
+        LOCAL_VAR: { type: 'local', key: 'local_key' },
+        VAULT_VAR: { type: 'vault', key: 'vault_key' },
+        OPENBAO_VAR: { type: 'openbao', key: 'openbao_key' },
+      },
+      providers: {
+        local: { type: 'local', enabled: true, config: {} },
+        vault: { type: 'vault', enabled: false, config: {} },
+        openbao: { type: 'openbao', enabled: false, config: {} },
+      }
+    };
+
+    const filteredConfig = filterDisabledProviders(config);
+
+    // Should only keep the local variable
+    expect(filteredConfig.variables).toHaveLength(1);
+    expect(filteredConfig.variables[0].name).toBe('LOCAL_VAR');
+    
+    // Should only keep the local source
+    expect(filteredConfig.sources).toBeDefined();
+    expect(Object.keys(filteredConfig.sources!)).toHaveLength(1);
+    expect(filteredConfig.sources!.LOCAL_VAR).toBeDefined();
+  });
+
+  test('should keep variables without sources', () => {
+    const config: EnvoiConfig = {
+      variables: [
+        { name: 'NO_SOURCE_VAR', required: false, description: 'Variable without source' },
+        { name: 'VAULT_VAR', required: false, description: 'Vault variable' },
+      ],
+      sources: {
+        VAULT_VAR: { type: 'vault', key: 'vault_key' },
+      },
+      providers: {
+        vault: { type: 'vault', enabled: false, config: {} },
+      }
+    };
+
+    const filteredConfig = filterDisabledProviders(config);
+
+    // Should keep the variable without source
+    expect(filteredConfig.variables).toHaveLength(1);
+    expect(filteredConfig.variables[0].name).toBe('NO_SOURCE_VAR');
+    
+    // Should filter out the vault source
+    expect(filteredConfig.sources).toBeDefined();
+    expect(Object.keys(filteredConfig.sources!)).toHaveLength(0);
+  });
+
+  test('should preserve providers and command configuration', () => {
+    const config: EnvoiConfig = {
+      variables: [
+        { name: 'VAULT_VAR', required: false, description: 'Vault variable' },
+      ],
+      sources: {
+        VAULT_VAR: { type: 'vault', key: 'vault_key' },
+      },
+      providers: {
+        vault: { type: 'vault', enabled: false, config: {} },
+      },
+      command: {
+        default: 'npm start',
+        description: 'Start the application'
+      }
+    };
+
+    const filteredConfig = filterDisabledProviders(config);
+
+    // Should preserve providers configuration
+    expect(filteredConfig.providers).toEqual(config.providers);
+    
+    // Should preserve command configuration
+    expect(filteredConfig.command).toEqual(config.command);
+    
+    // Should filter out variables and sources
+    expect(filteredConfig.variables).toHaveLength(0);
+    expect(filteredConfig.sources).toBeDefined();
+    expect(Object.keys(filteredConfig.sources!)).toHaveLength(0);
+  });
+
+  test('should handle configuration without sources', () => {
+    const config: EnvoiConfig = {
+      variables: [
+        { name: 'VAR1', required: false, description: 'Variable 1' },
+        { name: 'VAR2', required: false, description: 'Variable 2' },
+      ],
+      providers: {
+        local: { type: 'local', enabled: true, config: {} },
+      }
+    };
+
+    const filteredConfig = filterDisabledProviders(config);
+
+    // Should keep all variables since they don't have sources
+    expect(filteredConfig.variables).toHaveLength(2);
+    expect(filteredConfig.variables.map(v => v.name)).toEqual(['VAR1', 'VAR2']);
+    
+    // Should not create sources object if it didn't exist
+    expect(filteredConfig.sources).toBeUndefined();
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:17.6-alpine
+    container_name: envoi-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: openbao
+      POSTGRES_USER: openbao
+      POSTGRES_PASSWORD: openbao_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U openbao -d openbao"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  openbao:
+    image: openbao/openbao:latest
+    container_name: envoi-openbao
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      OPENBAO_DEV_ROOT_TOKEN_ID: "dev-only-token"
+      OPENBAO_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+      OPENBAO_STORAGE_POSTGRES_CONNECTION_URL: "postgres://openbao:openbao_password@postgres:5432/openbao?sslmode=disable"
+      OPENBAO_STORAGE_POSTGRES_TABLE: "vault_kv_store"
+      OPENBAO_STORAGE_POSTGRES_MAX_OPEN_CONNECTIONS: "10"
+      OPENBAO_STORAGE_POSTGRES_MAX_IDLE_CONNECTIONS: "2"
+      OPENBAO_STORAGE_POSTGRES_CONNECTION_TIMEOUT: "30s"
+    ports:
+      - "8200:8200"
+    volumes:
+      - openbao_data:/vault/file
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8200/v1/sys/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  postgres_data:
+  openbao_data:
+
+networks:
+  default:
+    name: envoi-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,18 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:17.6-alpine
     container_name: envoi-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: openbao
-      POSTGRES_USER: openbao
-      POSTGRES_PASSWORD: openbao_password
-    ports:
-      - "5432:5432"
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    networks:
+      - envoi-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U openbao -d openbao"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -27,27 +25,34 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      OPENBAO_DEV_ROOT_TOKEN_ID: "dev-only-token"
-      OPENBAO_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
-      OPENBAO_STORAGE_POSTGRES_CONNECTION_URL: "postgres://openbao:openbao_password@postgres:5432/openbao?sslmode=disable"
-      OPENBAO_STORAGE_POSTGRES_TABLE: "vault_kv_store"
-      OPENBAO_STORAGE_POSTGRES_MAX_OPEN_CONNECTIONS: "10"
-      OPENBAO_STORAGE_POSTGRES_MAX_IDLE_CONNECTIONS: "2"
-      OPENBAO_STORAGE_POSTGRES_CONNECTION_TIMEOUT: "30s"
+      VAULT_ADDR: "http://127.0.0.1:8200"
+      BAO_API_ADDR: "http://0.0.0.0:8200"
+      BAO_CLUSTER_ADDR: "http://0.0.0.0:8201"
+      BAO_PG_CONNECTION_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
+      BAO_PG_TABLE: "vault_kv_store"
+      BAO_PG_MAX_OPEN_CONNECTIONS: "10"
+      BAO_PG_MAX_IDLE_CONNECTIONS: "2"
+      BAO_PG_CONNECTION_TIMEOUT: "30s"
+      
+      # Configuración adicional
+      BAO_LOG_LEVEL: "info"
+    command: ["server", "-config=/bao/config/config.hcl"]
+    volumes:
+      - ./providers/openbao/config:/bao/config
     ports:
       - "8200:8200"
-    volumes:
-      - openbao_data:/vault/file
+    cap_add:
+      - IPC_LOCK
+    networks:
+      - envoi-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8200/v1/sys/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8200/v1/sys/health"]
       interval: 30s
       timeout: 10s
       retries: 3
 
 volumes:
   postgres_data:
-  openbao_data:
 
 networks:
-  default:
-    name: envoi-network
+  envoi-network:

--- a/envoi-claude-glm.yml
+++ b/envoi-claude-glm.yml
@@ -13,20 +13,20 @@ variables:
   - name: ANTHROPIC_AUTH_TOKEN
     required: true
     description: "Claude Code API authentication token"
-  - name: DOKPLOY_API_KEY
+  - name: DOKPLOY_TDS_API_KEY
     required: true
     description: "Dokploy API key for TDS"
 
 sources:
   ANTHROPIC_BASE_URL:
     type: openbao
-    path: secret/local/claude_glm
+    path: secrets/data/claude_glm
   ANTHROPIC_AUTH_TOKEN:
     type: openbao
-    path: secret/local/claude_glm
-  DOKPLOY_API_KEY:
+    path: secrets/data/claude_glm
+  DOKPLOY_TDS_API_KEY:
     type: openbao
-    path: secret/local/mcp_envs
+    path: secrets/data/mcp
 
 # Default command to execute when no command-line arguments are provided
 command:

--- a/envoi-claude.yml
+++ b/envoi-claude.yml
@@ -1,0 +1,26 @@
+variables:
+  - name: ANTHROPIC_BASE_URL
+    required: true
+    description: "Claude Code API base URL"
+  - name: ANTHROPIC_AUTH_TOKEN
+    required: true
+    description: "Claude Code API authentication token"
+  - name: DOKPLOY_API_KEY
+    required: true
+    description: "Dokploy API key for TDS"
+
+sources:
+  ANTHROPIC_BASE_URL:
+    type: local
+    file: .env
+  ANTHROPIC_AUTH_TOKEN:
+    type: local
+    file: .env
+  DOKPLOY_API_KEY:
+    type: local
+    file: .env
+
+# Default command to execute when no command-line arguments are provided
+command:
+  default: "claude"
+  description: "Run Claude Code"

--- a/envoi-claude.yml
+++ b/envoi-claude.yml
@@ -1,3 +1,11 @@
+providers:  
+  openbao:
+    type: openbao
+    enabled: true
+    config:
+      address: "${OPENBAO_ADDR}"
+      token: "${OPENBAO_TOKEN}"
+
 variables:
   - name: ANTHROPIC_BASE_URL
     required: true
@@ -11,14 +19,14 @@ variables:
 
 sources:
   ANTHROPIC_BASE_URL:
-    type: local
-    file: .env
+    type: openbao
+    path: secret/local/claude_glm
   ANTHROPIC_AUTH_TOKEN:
-    type: local
-    file: .env
+    type: openbao
+    path: secret/local/claude_glm
   DOKPLOY_API_KEY:
-    type: local
-    file: .env
+    type: openbao
+    path: secret/local/mcp_envs
 
 # Default command to execute when no command-line arguments are provided
 command:

--- a/envoi.example.yml
+++ b/envoi.example.yml
@@ -1,3 +1,17 @@
+providers:
+  local:
+    type: local
+    enabled: true
+    config:
+      file: .env
+  
+  openbao:
+    type: openbao
+    enabled: true
+    config:
+      address: "http://localhost:8200"
+      token: "${OPENBAO_TOKEN}"
+
 variables:
   - name: DATABASE_URL
     required: true
@@ -23,8 +37,14 @@ sources:
     type: local
     file: .env
     key: EXTERNAL_API_KEY
-  # Example for Vault integration (v1.1)
+  # Example for OpenBao integration (v1.1)
   # SECRET_TOKEN:
+  #   type: openbao
+  #   path: secret/data/myapp
+  #   key: secret_token
+  # 
+  # Example for Vault integration (v1.1)
+  # LEGACY_TOKEN:
   #   type: vault
   #   path: secret/data/myapp
   #   key: api_token

--- a/envoi.yml
+++ b/envoi.yml
@@ -7,9 +7,9 @@ providers:
   
   openbao:
     type: openbao
-    enabled: true
+    enabled: false
     config:
-      address: "http://localhost:8200"
+      address: "${OPENBAO_ADDR}"
       token: "${OPENBAO_TOKEN}"
 
 variables:

--- a/envoi.yml
+++ b/envoi.yml
@@ -1,26 +1,58 @@
+providers:
+  local:
+    type: local
+    enabled: true
+    config:
+      file: .env
+  
+  openbao:
+    type: openbao
+    enabled: true
+    config:
+      address: "http://localhost:8200"
+      token: "${OPENBAO_TOKEN}"
+
 variables:
-  - name: ANTHROPIC_BASE_URL
+  - name: DATABASE_URL
     required: true
-    description: "Claude Code API base URL"
-  - name: ANTHROPIC_AUTH_TOKEN
+    description: "Database connection string"
+  - name: API_KEY
     required: true
-    description: "Claude Code API authentication token"
-  - name: DOKPLOY_API_KEY
-    required: true
-    description: "Dokploy API key for TDS"
+    description: "API key for external service"
+  - name: NODE_ENV
+    required: false
+    default: "development"
+    description: "Node.js environment"
+  - name: SECRET_TOKEN
+    required: false
+    description: "Secret token from OpenBao"
+  - name: PORT
+    required: false
+    default: "3000"
+    description: "Server port"
 
 sources:
-  ANTHROPIC_BASE_URL:
+  DATABASE_URL:
     type: local
     file: .env
-  ANTHROPIC_AUTH_TOKEN:
+    key: DB_URL
+  API_KEY:
     type: local
     file: .env
-  DOKPLOY_API_KEY:
-    type: local
-    file: .env
+    key: EXTERNAL_API_KEY
+  # Example for OpenBao integration (v1.1)
+  SECRET_TOKEN:
+    type: openbao
+    path: secret/data/myapp
+    key: secret_key
+  # 
+  # Example for Vault integration (v1.1)
+  # LEGACY_TOKEN:
+  #   type: vault
+  #  path: secret/data/myapp
+  #   key: api_token
 
 # Default command to execute when no command-line arguments are provided
 command:
-  default: "claude"
-  description: "Run Claude Code"
+  default: "npm run envoi:test"
+  description: "Test the envoi default command"

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,9 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(node-fetch)/).+\\.js$',
+  ],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
         "dotenv": "^16.4.5",
-        "node-vault": "^0.10.5",
+        "node-fetch": "^3.3.2",
         "yaml": "^2.4.2",
         "zod": "^3.23.8"
       },
@@ -1220,47 +1220,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@postman/form-data": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@postman/form-data/-/form-data-3.1.1.tgz",
-      "integrity": "sha512-vjh8Q2a8S6UCm/KKs31XFJqEEgmbjBmpPNVV2eVav6905wyFAwaUOBGA1NPBI4ERH9MMZc6w0umFgM6WbEPMdg==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@postman/tough-cookie": {
-      "version": "4.1.3-postman.1",
-      "resolved": "https://registry.npmjs.org/@postman/tough-cookie/-/tough-cookie-4.1.3-postman.1.tgz",
-      "integrity": "sha512-txpgUqZOnWYnUHZpHjkfb0IwVH4qJmyq77pPnJLlfhMtdCLMFTEeQHlzQiK906aaNCe4NEB5fGJHo9uzGbFMeA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@postman/tunnel-agent": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.4.tgz",
-      "integrity": "sha512-CJJlq8V7rNKhAw4sBfjixKpJW00SHqebqNUQKxMoepgeWZIbdPcD+rguRcivGhS4N12PymDcKgUgSD4rVC+RjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1679,15 +1638,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1796,45 +1746,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1979,21 +1890,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2122,12 +2018,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2228,18 +2118,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -2261,12 +2139,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "license": "MIT"
     },
     "node_modules/create-jest": {
@@ -2313,22 +2185,20 @@
         "node": ">= 8"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
       "engines": {
-        "node": ">=0.10"
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2372,15 +2242,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -2449,16 +2310,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2760,21 +2611,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2846,6 +2682,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2911,13 +2770,16 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -2993,15 +2855,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -3165,20 +3018,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-signature": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
-      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^2.0.2",
-        "sshpk": "^1.18.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3264,15 +3103,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3373,24 +3203,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4066,12 +3884,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4099,12 +3911,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4119,12 +3925,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4136,21 +3936,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
-      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
       }
     },
     "node_modules/keyv": {
@@ -4308,27 +4093,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -4369,16 +4133,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4394,6 +4150,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4407,21 +4201,6 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-vault": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.10.5.tgz",
-      "integrity": "sha512-sIyB/5296U2tMT7hH1nrkoYUXkRxuLsG40fgUHaBhzM+G/uyBKBo+QNsvKqE5FNq24QJM+tr97N+knLQiEEcSg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "mustache": "^4.2.0",
-        "postman-request": "^2.88.1-postman.42",
-        "tv4": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4444,15 +4223,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/once": {
@@ -4719,37 +4489,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/postman-request": {
-      "version": "2.88.1-postman.43",
-      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.43.tgz",
-      "integrity": "sha512-5ivoZnMvnX47/HA7mk2GQubZsnXptlJGVyO0hLV3MTK/MDgJVnB/q3bUgzU4KhwG8OBxe2L8uqv3ZpK6mp+RdA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@postman/form-data": "~3.1.1",
-        "@postman/tough-cookie": "~4.1.3-postman.1",
-        "@postman/tunnel-agent": "^0.6.4",
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.12.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "http-signature": "~1.4.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "^2.1.35",
-        "oauth-sign": "~0.9.0",
-        "qs": "~6.5.3",
-        "safe-buffer": "^5.1.2",
-        "socks-proxy-agent": "^8.0.5",
-        "stream-length": "^1.0.2",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4802,22 +4541,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4838,21 +4566,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -4892,12 +4605,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5015,32 +4722,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -5101,44 +4782,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5167,31 +4810,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -5213,15 +4831,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stream-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
-      "integrity": "sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==",
-      "license": "WTFPL",
-      "dependencies": {
-        "bluebird": "^2.6.2"
       }
     },
     "node_modules/string-length": {
@@ -5513,30 +5122,6 @@
         }
       }
     },
-    "node_modules/tv4": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
-      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
-      "license": [
-        {
-          "type": "Public Domain",
-          "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
-        },
-        {
-          "type": "MIT",
-          "url": "http://jsonary.com/LICENSE.txt"
-        }
-      ],
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5608,15 +5193,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -5658,25 +5234,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -5699,20 +5256,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -5721,6 +5264,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "envoi": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/index.js",
     "dev": "ts-node src/index.ts",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envoi",
   "version": "1.0.0",
-  "description": "Environment-agnostic configuration orchestrator for consistent application deployment",
+  "description": "Environment-agnostic configuration orchestrator with OpenBao and HashiCorp Vault support",
   "main": "dist/index.js",
   "bin": {
     "envoi": "dist/index.js"
@@ -22,6 +22,7 @@
     "configuration",
     "env",
     "secrets",
+    "openbao",
     "vault",
     "cli",
     "deployment",
@@ -36,7 +37,7 @@
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "dotenv": "^16.4.5",
-    "node-vault": "^0.10.5",
+    "node-fetch": "^3.3.2",
     "yaml": "^2.4.2",
     "zod": "^3.23.8"
   },

--- a/providers/openbao/config/config.hcl
+++ b/providers/openbao/config/config.hcl
@@ -1,0 +1,7 @@
+ui = true
+storage "postgresql" {}
+
+listener "tcp" {
+  address = "0.0.0.0:8200"
+  tls_disable = 1
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -15,7 +15,7 @@ export async function loadConfig(configPath: string): Promise<EnvoiConfig> {
     
     return validateConfig(data);
   } catch (error) {
-    Logger.errorWithContext('Failed to load configuration:', error);
+    Logger.errorWithContext('[Loader] Failed to load configuration:', error);
     if (error instanceof Error) {
       if (error.message.includes('ENOENT')) {
         throw new EnvoiError(`Configuration file not found: ${configPath}`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,9 +1,11 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { validateConfig } from './schema';
+
 import { EnvoiConfig } from '../types';
 import { EnvoiError } from '../utils/errors';
+import { Logger } from '../utils/logger';
+import { validateConfig } from './schema';
 
 export async function loadConfig(configPath: string): Promise<EnvoiConfig> {
   try {
@@ -13,6 +15,7 @@ export async function loadConfig(configPath: string): Promise<EnvoiConfig> {
     
     return validateConfig(data);
   } catch (error) {
+    Logger.errorWithContext('Failed to load configuration:', error);
     if (error instanceof Error) {
       if (error.message.includes('ENOENT')) {
         throw new EnvoiError(`Configuration file not found: ${configPath}`);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -8,7 +8,7 @@ const VariableDefinitionSchema = z.object({
 });
 
 const VariableSourceSchema = z.object({
-  type: z.enum(['local', 'vault']),
+  type: z.enum(['local', 'vault', 'openbao']),
   file: z.string().optional(),
   key: z.string().optional(),
   path: z.string().optional(),
@@ -19,15 +19,26 @@ const CommandConfigSchema = z.object({
   description: z.string().optional(),
 });
 
+const ProviderConfigSchema = z.object({
+  type: z.enum(['local', 'vault', 'openbao']),
+  enabled: z.boolean().default(true),
+  config: z.record(z.any()).optional(),
+});
+
+const ProvidersConfigSchema = z.record(ProviderConfigSchema);
+
 const EnvoiConfigSchema = z.object({
   variables: z.array(VariableDefinitionSchema),
   sources: z.record(VariableSourceSchema).optional(),
+  providers: ProvidersConfigSchema.optional(),
   command: CommandConfigSchema.optional(),
 });
 
 export type VariableDefinition = z.infer<typeof VariableDefinitionSchema>;
 export type VariableSource = z.infer<typeof VariableSourceSchema>;
 export type CommandConfig = z.infer<typeof CommandConfigSchema>;
+export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;
+export type ProvidersConfig = z.infer<typeof ProvidersConfigSchema>;
 export type EnvoiConfig = z.infer<typeof EnvoiConfigSchema>;
 
 export function validateConfig(data: unknown): EnvoiConfig {

--- a/src/core/commands/BaseCommand.ts
+++ b/src/core/commands/BaseCommand.ts
@@ -1,0 +1,57 @@
+import { ProgramCommand, ProgramOption } from '../../types';
+
+import { EnvoiConfig } from '../../config/schema';
+import { EnvoiError } from '../../utils/errors';
+import { Logger } from '../../utils/logger';
+import { filterDisabledProviders } from '../../utils/provider-filter';
+import { loadConfig } from '../../config/loader';
+import { providerRegistry } from '../../providers/registry';
+import { registerProvidersFromConfig } from '../../providers/dynamic-registration';
+
+export abstract class BaseCommand implements ProgramCommand {
+  abstract command: string;
+  abstract description: string;
+  abstract options: ProgramOption[];
+  
+  protected async setupEnvironment(configPath: string, verbose: boolean): Promise<EnvoiConfig> {
+    Logger.setDebug(verbose);
+    
+    // Load configuration first to determine which providers to register
+    let config;
+    try {
+      config = await loadConfig(configPath);
+    } catch (error) {
+      console.error('Config loading error:', error);
+      throw error;
+    }
+    
+    if (verbose) {
+      Logger.info(`[BaseCommand] Loaded configuration from ${configPath}`);
+    }
+    
+    // Register providers based on configuration
+    registerProvidersFromConfig(config, verbose);
+    
+    // Filter out sources and variables for disabled providers
+    const filteredConfig = filterDisabledProviders(config);
+    
+    if (verbose) {
+      Logger.info(`[BaseCommand] Registered providers: ${providerRegistry.getRegisteredProviders().join(', ')}`);
+      Logger.info(`[BaseCommand] Filtered configuration to ${filteredConfig.variables.length} variables from ${config.variables.length} total`);
+    }
+    
+    return filteredConfig;
+  }
+  
+  protected handleError(error: unknown): never {
+    if (error instanceof EnvoiError) {
+      Logger.error('[BaseCommand] ', error.message);
+      process.exit(1);
+    } else {
+      Logger.error('[BaseCommand] An unexpected error occurred:', error);
+      process.exit(1);
+    }
+  }
+  
+  abstract action(...args: unknown[]): Promise<void>;
+}

--- a/src/core/commands/EnvCommand.ts
+++ b/src/core/commands/EnvCommand.ts
@@ -1,0 +1,70 @@
+import { BaseCommand } from './BaseCommand';
+import { Logger } from '../../utils/logger';
+import { ProgramOption } from '../../types';
+import { resolveVariables } from '../../core/resolver';
+
+export class EnvCommand extends BaseCommand {
+  command = 'env';
+  description = `Show loaded environment variables and their sources
+
+Displays all resolved environment variables with their values and where they were loaded from.
+Source information shows: "environment" (existing env vars), "local:KEY" (.env files), "vault:PATH" (HashiCorp Vault), "openbao:PATH" (OpenBao), or "default".
+Also shows the default command configuration if defined in envoi.yml.
+
+Examples:
+  envoi env
+  envoi env --config ./config/envoi.yml`;
+  
+  options: ProgramOption[] = [
+    {
+      flags: '-c, --config <path>',
+      description: 'Path to envoi.yml configuration file (default: "./envoi.yml")',
+      defaultValue: './envoi.yml'
+    },
+    {
+      flags: '-v, --verbose',
+      description: 'Enable verbose output showing variable resolution process',
+      defaultValue: false
+    }
+  ];
+
+  async action(options: { config: string; verbose: boolean }): Promise<void> {
+    Logger.debug('Starting env command');
+    
+    try {
+      // Setup environment and get filtered config
+      const filteredConfig = await this.setupEnvironment(options.config, options.verbose);
+      
+      const resolvedVariables = await resolveVariables(filteredConfig, options.verbose);
+
+      Logger.header('envoi environment variables:');
+      Logger.blank();
+
+      if (resolvedVariables.length === 0) {
+        Logger.noVariables();
+        return;
+      }
+
+      const maxNameLength = Math.max(...resolvedVariables.map(v => v.name.length));
+      
+      resolvedVariables.forEach(variable => {
+        Logger.variable(variable.name, variable.value, variable.source, maxNameLength + 2);
+      });
+
+      // Show command configuration if it exists
+      if (filteredConfig.command?.default) {
+        Logger.blank();
+        Logger.header('Default Command:');
+        Logger.blank();
+        
+        const commandInfo = filteredConfig.command.description 
+          ? `${filteredConfig.command.default} - ${filteredConfig.command.description}`
+          : filteredConfig.command.default;
+        
+        Logger.plain(`  ${commandInfo}`);
+      }
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+}

--- a/src/core/commands/ExecCommand.ts
+++ b/src/core/commands/ExecCommand.ts
@@ -1,0 +1,80 @@
+import { BaseCommand } from './BaseCommand';
+import { EnvoiError } from '../../utils/errors';
+import { Logger } from '../../utils/logger';
+import { ProgramOption } from '../../types';
+import { resolveAndExecute } from '../../core/resolver';
+
+export class ExecCommand extends BaseCommand {
+  command = 'exec';
+  description = `Execute a command with injected environment variables
+Loads variables from configured sources (.env files, HashiCorp Vault, OpenBao) and injects them into the command environment.
+Variables are resolved in order: existing env → configured sources → defaults.
+
+If no command is provided via command line, uses the default command from envoi.yml.
+Command line arguments override the default configuration.
+
+Examples:
+  envoi exec                    # Uses default command from envoi.yml
+  envoi exec "node server.js"   # Override with command line
+  envoi exec -- node server.js  # New -- separator syntax
+  envoi exec "npm start" --config ./config/envoi.yml
+  envoi exec -- npm start --config ./config/envoi.yml
+  envoi exec "echo $DATABASE_URL" --verbose`;
+  
+  options: ProgramOption[] = [
+    {
+      flags: '-c, --config <path>',
+      description: 'Path to envoi.yml configuration file (default: "./envoi.yml")',
+      defaultValue: './envoi.yml'
+    },
+    {
+      flags: '-v, --verbose',
+      description: 'Enable verbose output showing variable resolution process',
+      defaultValue: false
+    }
+  ];
+
+  async action(options: { config: string; verbose: boolean }, command: { args: string[] }): Promise<void> {
+    Logger.debug('[ExecCommand] Starting exec command');
+    
+    try {
+      const rawArgs = command.args;
+      const separatorIndex = rawArgs.indexOf('--');
+      
+      let fullCommand: string | undefined;
+      
+      if (separatorIndex !== -1) {
+        // New syntax: envoi exec -- node server.js
+        const commandArgs = rawArgs.slice(separatorIndex + 1);
+        fullCommand = commandArgs.join(' ');
+      } else if (rawArgs.length > 0) {
+        // Old syntax: envoi exec "node server.js"
+        fullCommand = rawArgs.join(' ');
+      }
+      
+      // Setup environment and get filtered config
+      const filteredConfig = await this.setupEnvironment(options.config, options.verbose);
+      
+      // If no command-line command provided, use default from config
+      if (!fullCommand) {
+        if (filteredConfig.command?.default) {
+          fullCommand = filteredConfig.command.default;
+          if (options.verbose) {
+            Logger.info(`[ExecCommand] Using default command from envoi.yml: ${fullCommand}`);
+          }
+        } else {
+          throw new EnvoiError('No command specified. Either provide a command via command line or define a default command in envoi.yml. Use: envoi exec -- <command> or envoi exec "<command>"');
+        }
+      }
+      
+      if (options.verbose) {
+        Logger.info(`[ExecCommand] Loading configuration from: ${options.config}`);
+        Logger.info(`[ExecCommand] Executing command: ${fullCommand}`);
+      }
+
+      await resolveAndExecute(filteredConfig, fullCommand, options.verbose);
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+}

--- a/src/core/commands/discover.ts
+++ b/src/core/commands/discover.ts
@@ -1,0 +1,97 @@
+import { BaseCommand } from './BaseCommand';
+import { Logger } from '../../utils/logger';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface DiscoveredCommand {
+  name: string;
+  className: string;
+  CommandClass: new () => BaseCommand;
+  filePath: string;
+}
+
+export class CommandDiscovery {
+  private static readonly COMMAND_PATTERN = /^(.+?)Command\.ts$/;
+  private static readonly EXCLUDED_FILES = ['BaseCommand.ts', 'index.ts', 'discover.ts', 'registry.ts'];
+
+  static async discoverCommands(commandsDir?: string): Promise<DiscoveredCommand[]> {
+    Logger.setDebug(process.env.DEBUG === 'true' || process.env.DEBUG === '1');
+    // Default to dist directory when running compiled code
+    if (!commandsDir) {
+      commandsDir = path.join(process.cwd(), process.env.NODE_ENV === 'development' ? 'src/core/commands' : 'dist/core/commands');
+    }
+    try {
+      Logger.debug(`[CommandDiscovery] Looking for commands in: ${commandsDir}`);
+      
+      const files = await fs.readdir(commandsDir);
+      
+      Logger.debug(`[CommandDiscovery] Found files: ${files.toString()}`);
+      
+      // Determine file extension based on environment
+      const isDevelopment = commandsDir.includes('src');
+      const fileExtension = isDevelopment ? '.ts' : '.js';
+      
+      const commandFiles = files.filter(file => 
+        file.endsWith(fileExtension) && 
+        !this.EXCLUDED_FILES.map(f => f.replace('.ts', fileExtension)).includes(file) &&
+        this.COMMAND_PATTERN.test(file.replace('.js', '.ts'))
+      );
+      
+      Logger.debug(`[CommandDiscovery] Looking for ${fileExtension} files`);
+      Logger.debug(`[CommandDiscovery] Command files after filter:`, commandFiles);
+
+      const discoveredCommands: DiscoveredCommand[] = [];
+
+      for (const file of commandFiles) {
+        const match = file.replace('.js', '.ts').match(this.COMMAND_PATTERN);
+        if (!match) continue;
+
+        const commandName = match[1].toLowerCase();
+        const className = match[1] + 'Command';
+        const filePath = path.join(commandsDir, file);
+
+        try {
+          // Dynamic import to get the command class
+          const module = await import(filePath);
+          const CommandClass = module[className];
+
+          if (!CommandClass || typeof CommandClass !== 'function') {
+            console.warn(`Warning: Could not find exported class '${className}' in ${file}`);
+            continue;
+          }
+
+          // Verify it extends BaseCommand
+          const tempInstance = new CommandClass();
+          if (!(tempInstance instanceof BaseCommand)) {
+            console.warn(`Warning: Class '${className}' in ${file} does not extend BaseCommand`);
+            continue;
+          }
+
+          discoveredCommands.push({
+            name: commandName,
+            className,
+            CommandClass,
+            filePath
+          });
+        } catch (error) {
+          console.warn(`Warning: Failed to load command from ${file}:`, error);
+        }
+      }
+
+      return discoveredCommands;
+    } catch (error) {
+      console.error('Error discovering commands:', error);
+      return [];
+    }
+  }
+
+  static async createCommandInstances(commandsDir: string = __dirname): Promise<BaseCommand[]> {
+    const discoveredCommands = await this.discoverCommands(commandsDir);
+    return discoveredCommands.map(({ CommandClass }) => new CommandClass());
+  }
+
+  static async getCommandClasses(commandsDir: string = __dirname): Promise<Array<new () => BaseCommand>> {
+    const discoveredCommands = await this.discoverCommands(commandsDir);
+    return discoveredCommands.map(({ CommandClass }) => CommandClass);
+  }
+}

--- a/src/core/commands/index.ts
+++ b/src/core/commands/index.ts
@@ -1,0 +1,7 @@
+export { BaseCommand } from './BaseCommand';
+export { ExecCommand } from './ExecCommand';
+export { EnvCommand } from './EnvCommand';
+
+// Dynamic loading system
+export { CommandDiscovery } from './discover';
+export { CommandRegistry } from './registry';

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import { BaseCommand } from './BaseCommand';
+import { CommandDiscovery } from './discover';
+
+export interface CommandRegistration {
+  command: BaseCommand;
+  programCommand: Command;
+}
+
+export class CommandRegistry {
+  private static registrations: CommandRegistration[] = [];
+
+  static async registerCommands(program: Command, commandsDir?: string): Promise<CommandRegistration[]> {
+    const commands = await CommandDiscovery.createCommandInstances(commandsDir);
+    
+    this.registrations = [];
+
+    for (const command of commands) {
+      const registration = this.registerCommand(program, command);
+      this.registrations.push(registration);
+    }
+
+    return this.registrations;
+  }
+
+  private static registerCommand(program: Command, command: BaseCommand): CommandRegistration {
+    // Check if this should be the default command
+    const isDefault = command.command === 'exec'; // exec is our default command
+
+    // Create the command
+    const programCommand = program
+      .command(command.command, { isDefault })
+      .description(command.description);
+
+    // Add allowUnknownOption for exec command
+    if (command.command === 'exec') {
+      programCommand.allowUnknownOption();
+    }
+
+    // Add options to the command
+    command.options.forEach(option => {
+      programCommand.option(
+        option.flags,
+        option.description || '',
+        option.defaultValue
+      );
+    });
+
+    // Set the action handler
+    programCommand.action(command.action.bind(command));
+
+    return {
+      command,
+      programCommand
+    };
+  }
+
+  static getRegistrations(): CommandRegistration[] {
+    return this.registrations;
+  }
+
+  static getCommandByName(name: string): BaseCommand | undefined {
+    return this.registrations.find(reg => reg.command.command === name)?.command;
+  }
+
+  static clear(): void {
+    this.registrations = [];
+  }
+}

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -15,7 +15,7 @@ export async function resolveVariables(config: EnvoiConfig, verbose: boolean): P
       let sourceInfo = '';
 
       // First check if variable is already in environment
-      Logger.debug(`Resolving variable '${variable.name}' using process.env: ${process.env[variable.name]}`);
+      Logger.debug(`[Resolver] Resolving variable '${variable.name}' using process.env: ${process.env[variable.name]}`);
       const envValue = process.env[variable.name];
       if (envValue !== undefined) {
         value = envValue;
@@ -24,7 +24,7 @@ export async function resolveVariables(config: EnvoiConfig, verbose: boolean): P
 
       // If not in environment, try to resolve from sources
       if (value === undefined && config.sources && config.sources[variable.name]) {
-        Logger.debug(`Attempting to resolve variable '${variable.name}' from configured sources`);
+        Logger.debug(`[Resolver] Attempting to resolve variable '${variable.name}' from configured sources`);
         const variableSource = config.sources[variable.name];
         const provider = providerRegistry.get(variableSource.type);
         
@@ -79,9 +79,9 @@ export async function resolveAndExecute(
   const resolvedVariables = await resolveVariables(config, verbose);
 
   if (verbose) {
-    Logger.debug('Resolved variables:');
+    Logger.debug('[Resolver] Resolved variables:');
     resolvedVariables.forEach(variable => {
-      Logger.debugDetail(`${variable.name}: ${variable.source}`);
+      Logger.debugDetail(`[Resolver] ${variable.name}: ${variable.source}`);
     });
   }
 
@@ -99,7 +99,7 @@ export async function resolveAndExecute(
     }
 
     if (verbose) {
-      Logger.debug(`Executing: ${command}`);
+      Logger.debug(`[Resolver] Executing: ${command}`);
     }
 
     const child = spawn(cmd, args, {

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -1,10 +1,12 @@
-import { spawn } from 'child_process';
 import { EnvoiConfig, ResolvedVariable } from '../types';
-import { providerRegistry } from '../providers/registry';
-import { ValidationError, ProviderError } from '../utils/errors';
-import { Logger } from '../utils/logger';
+import { ProviderError, ValidationError } from '../utils/errors';
 
-export async function resolveVariables(config: EnvoiConfig): Promise<ResolvedVariable[]> {
+import { Logger } from '../utils/logger';
+import { providerRegistry } from '../providers/registry';
+import { spawn } from 'child_process';
+
+export async function resolveVariables(config: EnvoiConfig, verbose: boolean): Promise<ResolvedVariable[]> {
+  Logger.setDebug(verbose);
   const resolvedVariables: ResolvedVariable[] = [];
 
   for (const variable of config.variables) {
@@ -13,6 +15,7 @@ export async function resolveVariables(config: EnvoiConfig): Promise<ResolvedVar
       let sourceInfo = '';
 
       // First check if variable is already in environment
+      Logger.debug(`Resolving variable '${variable.name}' using process.env: ${process.env[variable.name]}`);
       const envValue = process.env[variable.name];
       if (envValue !== undefined) {
         value = envValue;
@@ -21,6 +24,7 @@ export async function resolveVariables(config: EnvoiConfig): Promise<ResolvedVar
 
       // If not in environment, try to resolve from sources
       if (value === undefined && config.sources && config.sources[variable.name]) {
+        Logger.debug(`Attempting to resolve variable '${variable.name}' from configured sources`);
         const variableSource = config.sources[variable.name];
         const provider = providerRegistry.get(variableSource.type);
         
@@ -72,7 +76,7 @@ export async function resolveAndExecute(
   verbose: boolean = false
 ): Promise<void> {
   Logger.setDebug(verbose);
-  const resolvedVariables = await resolveVariables(config);
+  const resolvedVariables = await resolveVariables(config, verbose);
 
   if (verbose) {
     Logger.debug('Resolved variables:');

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import { EnvoiError } from './utils/errors';
 import { LocalProvider } from './providers/local';
 import { VaultProvider } from './providers/vault';
+import { OpenBaoProvider } from './providers/openbao';
 import { loadConfig } from './config/loader';
 import { providerRegistry } from './providers/registry';
 import { Logger } from './utils/logger';
@@ -21,16 +22,24 @@ try {
   Logger.warn('Vault provider not registered. Ensure dependencies are installed if you plan to use Vault.');
 }
 
+// Register OpenBao provider if dependencies are available
+try {
+  providerRegistry.register(new OpenBaoProvider());
+} catch (error) {
+  // OpenBao provider requires optional dependencies, fail gracefully
+  Logger.warn('OpenBao provider not registered. Ensure dependencies are installed if you plan to use OpenBao.');
+}
+
 const program = new Command();
 
 program
   .name('envoi')
-  .description('Environment-agnostic configuration orchestrator\n\nLoad environment variables from multiple sources (.env files, HashiCorp Vault) and execute commands with injected configuration.\nConfigure default commands in envoi.yml and override them with command-line arguments.\n\nExamples:\n  envoi exec                    # Uses default command from envoi.yml\n  envoi exec "node server.js"   # Override with command line\n  envoi exec -- node server.js  # New -- separator syntax\n  envoi env\n  envoi exec "echo $DATABASE_URL" --verbose')
+  .description('Environment-agnostic configuration orchestrator\n\nLoad environment variables from multiple sources (.env files, HashiCorp Vault, OpenBao) and execute commands with injected configuration.\nConfigure default commands in envoi.yml and override them with command-line arguments.\n\nExamples:\n  envoi exec                    # Uses default command from envoi.yml\n  envoi exec "node server.js"   # Override with command line\n  envoi exec -- node server.js  # New -- separator syntax\n  envoi env\n  envoi exec "echo $DATABASE_URL" --verbose')
   .version('1.0.0');
 
 program
   .command('exec', { isDefault: true })
-  .description('Execute a command with injected environment variables\n\nLoads variables from configured sources (.env files, HashiCorp Vault) and injects them into the command environment.\nVariables are resolved in order: existing env → configured sources → defaults.\n\nIf no command is provided via command line, uses the default command from envoi.yml.\nCommand line arguments override the default configuration.\n\nExamples:\n  envoi exec                    # Uses default command from envoi.yml\n  envoi exec "node server.js"   # Override with command line\n  envoi exec -- node server.js  # New -- separator syntax\n  envoi exec "npm start" --config ./config/envoi.yml\n  envoi exec -- npm start --config ./config/envoi.yml\n  envoi exec "echo $DATABASE_URL" --verbose')
+  .description('Execute a command with injected environment variables\n\nLoads variables from configured sources (.env files, HashiCorp Vault, OpenBao) and injects them into the command environment.\nVariables are resolved in order: existing env → configured sources → defaults.\n\nIf no command is provided via command line, uses the default command from envoi.yml.\nCommand line arguments override the default configuration.\n\nExamples:\n  envoi exec                    # Uses default command from envoi.yml\n  envoi exec "node server.js"   # Override with command line\n  envoi exec -- node server.js  # New -- separator syntax\n  envoi exec "npm start" --config ./config/envoi.yml\n  envoi exec -- npm start --config ./config/envoi.yml\n  envoi exec "echo $DATABASE_URL" --verbose')
   .allowUnknownOption()
   .option('-c, --config <path>', 'Path to envoi.yml configuration file (default: "./envoi.yml")', './envoi.yml')
   .option('-v, --verbose', 'Enable verbose output showing variable resolution process', false)
@@ -83,7 +92,7 @@ program
 
 program
   .command('env')
-  .description('Show loaded environment variables and their sources\n\nDisplays all resolved environment variables with their values and where they were loaded from.\nSource information shows: "environment" (existing env vars), "local:KEY" (.env files), "vault:PATH" (HashiCorp Vault), or "default".\nAlso shows the default command configuration if defined in envoi.yml.\n\nExamples:\n  envoi env\n  envoi env --config ./config/envoi.yml')
+  .description('Show loaded environment variables and their sources\n\nDisplays all resolved environment variables with their values and where they were loaded from.\nSource information shows: "environment" (existing env vars), "local:KEY" (.env files), "vault:PATH" (HashiCorp Vault), "openbao:PATH" (OpenBao), or "default".\nAlso shows the default command configuration if defined in envoi.yml.\n\nExamples:\n  envoi env\n  envoi env --config ./config/envoi.yml')
   .option('-c, --config <path>', 'Path to envoi.yml configuration file (default: "./envoi.yml")', './envoi.yml')
   .action(async (options) => {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,31 +4,11 @@ import { resolveAndExecute, resolveVariables } from './core/resolver';
 
 import { Command } from 'commander';
 import { EnvoiError } from './utils/errors';
-import { LocalProvider } from './providers/local';
-import { VaultProvider } from './providers/vault';
-import { OpenBaoProvider } from './providers/openbao';
+import { Logger } from './utils/logger';
+import { filterDisabledProviders } from './utils/provider-filter';
 import { loadConfig } from './config/loader';
 import { providerRegistry } from './providers/registry';
-import { Logger } from './utils/logger';
-
-// Register built-in providers
-providerRegistry.register(new LocalProvider());
-
-// Register Vault provider if dependencies are available
-try {
-  providerRegistry.register(new VaultProvider());
-} catch (error) {
-  // Vault provider requires optional dependencies, fail gracefully
-  Logger.warn('Vault provider not registered. Ensure dependencies are installed if you plan to use Vault.');
-}
-
-// Register OpenBao provider if dependencies are available
-try {
-  providerRegistry.register(new OpenBaoProvider());
-} catch (error) {
-  // OpenBao provider requires optional dependencies, fail gracefully
-  Logger.warn('OpenBao provider not registered. Ensure dependencies are installed if you plan to use OpenBao.');
-}
+import { registerProvidersFromConfig } from './providers/dynamic-registration';
 
 const program = new Command();
 
@@ -44,6 +24,8 @@ program
   .option('-c, --config <path>', 'Path to envoi.yml configuration file (default: "./envoi.yml")', './envoi.yml')
   .option('-v, --verbose', 'Enable verbose output showing variable resolution process', false)
   .action(async (options, command) => {
+    Logger.setDebug(options.verbose);
+    Logger.debug('Starting exec command');
     try {
       const rawArgs = command.args;
       const separatorIndex = rawArgs.indexOf('--');
@@ -59,7 +41,29 @@ program
         fullCommand = rawArgs.join(' ');
       }
       
-      const config = await loadConfig(options.config);
+      // Load configuration first to determine which providers to register
+      let config;
+      try {
+        config = await loadConfig(options.config);
+      } catch (error) {
+        console.error('Config loading error:', error);
+        throw error;
+      }
+      
+      if (options.verbose) {
+        Logger.info(`Loaded configuration from ${options.config}`);
+      }
+      
+      // Register providers based on configuration
+      registerProvidersFromConfig(config, options.verbose);
+      
+      // Filter out sources and variables for disabled providers
+      const filteredConfig = filterDisabledProviders(config);
+      
+      if (options.verbose) {
+        Logger.info(`Registered providers: ${providerRegistry.getRegisteredProviders().join(', ')}`);
+        Logger.info(`Filtered configuration to ${filteredConfig.variables.length} variables from ${config.variables.length} total`);
+      }
       
       // If no command-line command provided, use default from config
       if (!fullCommand) {
@@ -78,13 +82,14 @@ program
         Logger.info(`Executing command: ${fullCommand}`);
       }
 
-      await resolveAndExecute(config, fullCommand, options.verbose);
+      await resolveAndExecute(filteredConfig, fullCommand, options.verbose);
     } catch (error) {
       if (error instanceof EnvoiError) {
         Logger.error(error.message);
         process.exit(1);
       } else {
         Logger.errorWithContext('An unexpected error occurred:', error);
+        console.error('Full error:', error);
         process.exit(1);
       }
     }
@@ -94,10 +99,25 @@ program
   .command('env')
   .description('Show loaded environment variables and their sources\n\nDisplays all resolved environment variables with their values and where they were loaded from.\nSource information shows: "environment" (existing env vars), "local:KEY" (.env files), "vault:PATH" (HashiCorp Vault), "openbao:PATH" (OpenBao), or "default".\nAlso shows the default command configuration if defined in envoi.yml.\n\nExamples:\n  envoi env\n  envoi env --config ./config/envoi.yml')
   .option('-c, --config <path>', 'Path to envoi.yml configuration file (default: "./envoi.yml")', './envoi.yml')
+  .option('-v, --verbose', 'Enable verbose output showing variable resolution process', false)
   .action(async (options) => {
+    Logger.setDebug(options.verbose);
+    Logger.debug('Starting env command');
     try {
       const config = await loadConfig(options.config);
-      const resolvedVariables = await resolveVariables(config);
+      
+      // Register providers based on configuration
+      registerProvidersFromConfig(config, options.verbose);
+      
+      // Filter out sources and variables for disabled providers
+      const filteredConfig = filterDisabledProviders(config);
+      
+      if (options.verbose) {
+        Logger.info(`Registered providers: ${providerRegistry.getRegisteredProviders().join(', ')}`);
+        Logger.info(`Filtered configuration to ${filteredConfig.variables.length} variables from ${config.variables.length} total`);
+      }
+      
+      const resolvedVariables = await resolveVariables(filteredConfig, options.verbose);
 
       Logger.header('envoi environment variables:');
       Logger.blank();
@@ -131,6 +151,7 @@ program
         process.exit(1);
       } else {
         Logger.errorWithContext('An unexpected error occurred:', error);
+        console.error('Full error:', error);
         process.exit(1);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,160 +1,47 @@
 #!/usr/bin/env node
 
-import { resolveAndExecute, resolveVariables } from './core/resolver';
-
 import { Command } from 'commander';
-import { EnvoiError } from './utils/errors';
+import { CommandRegistry } from './core/commands';
 import { Logger } from './utils/logger';
-import { filterDisabledProviders } from './utils/provider-filter';
-import { loadConfig } from './config/loader';
-import { providerRegistry } from './providers/registry';
-import { registerProvidersFromConfig } from './providers/dynamic-registration';
+import packageJson from '../package.json';
 
 const program = new Command();
 
-program
-  .name('envoi')
-  .description('Environment-agnostic configuration orchestrator\n\nLoad environment variables from multiple sources (.env files, HashiCorp Vault, OpenBao) and execute commands with injected configuration.\nConfigure default commands in envoi.yml and override them with command-line arguments.\n\nExamples:\n  envoi exec                    # Uses default command from envoi.yml\n  envoi exec "node server.js"   # Override with command line\n  envoi exec -- node server.js  # New -- separator syntax\n  envoi env\n  envoi exec "echo $DATABASE_URL" --verbose')
-  .version('1.0.0');
+const customDescription = `${packageJson.description}
 
-program
-  .command('exec', { isDefault: true })
-  .description('Execute a command with injected environment variables\n\nLoads variables from configured sources (.env files, HashiCorp Vault, OpenBao) and injects them into the command environment.\nVariables are resolved in order: existing env → configured sources → defaults.\n\nIf no command is provided via command line, uses the default command from envoi.yml.\nCommand line arguments override the default configuration.\n\nExamples:\n  envoi exec                    # Uses default command from envoi.yml\n  envoi exec "node server.js"   # Override with command line\n  envoi exec -- node server.js  # New -- separator syntax\n  envoi exec "npm start" --config ./config/envoi.yml\n  envoi exec -- npm start --config ./config/envoi.yml\n  envoi exec "echo $DATABASE_URL" --verbose')
-  .allowUnknownOption()
-  .option('-c, --config <path>', 'Path to envoi.yml configuration file (default: "./envoi.yml")', './envoi.yml')
-  .option('-v, --verbose', 'Enable verbose output showing variable resolution process', false)
-  .action(async (options, command) => {
-    Logger.setDebug(options.verbose);
-    Logger.debug('Starting exec command');
-    try {
-      const rawArgs = command.args;
-      const separatorIndex = rawArgs.indexOf('--');
-      
-      let fullCommand: string | undefined;
-      
-      if (separatorIndex !== -1) {
-        // New syntax: envoi exec -- node server.js
-        const commandArgs = rawArgs.slice(separatorIndex + 1);
-        fullCommand = commandArgs.join(' ');
-      } else if (rawArgs.length > 0) {
-        // Old syntax: envoi exec "node server.js"
-        fullCommand = rawArgs.join(' ');
-      }
-      
-      // Load configuration first to determine which providers to register
-      let config;
-      try {
-        config = await loadConfig(options.config);
-      } catch (error) {
-        console.error('Config loading error:', error);
-        throw error;
-      }
-      
-      if (options.verbose) {
-        Logger.info(`Loaded configuration from ${options.config}`);
-      }
-      
-      // Register providers based on configuration
-      registerProvidersFromConfig(config, options.verbose);
-      
-      // Filter out sources and variables for disabled providers
-      const filteredConfig = filterDisabledProviders(config);
-      
-      if (options.verbose) {
-        Logger.info(`Registered providers: ${providerRegistry.getRegisteredProviders().join(', ')}`);
-        Logger.info(`Filtered configuration to ${filteredConfig.variables.length} variables from ${config.variables.length} total`);
-      }
-      
-      // If no command-line command provided, use default from config
-      if (!fullCommand) {
-        if (config.command?.default) {
-          fullCommand = config.command.default;
-          if (options.verbose) {
-            Logger.info(`Using default command from envoi.yml: ${fullCommand}`);
-          }
-        } else {
-          throw new EnvoiError('No command specified. Either provide a command via command line or define a default command in envoi.yml. Use: envoi exec -- <command> or envoi exec "<command>"');
-        }
-      }
-      
-      if (options.verbose) {
-        Logger.info(`Loading configuration from: ${options.config}`);
-        Logger.info(`Executing command: ${fullCommand}`);
-      }
+Load environment variables from multiple sources (.env files, HashiCorp Vault, OpenBao) and execute commands with injected configuration.
+Configure default commands in envoi.yml and override them with command-line arguments.
 
-      await resolveAndExecute(filteredConfig, fullCommand, options.verbose);
-    } catch (error) {
-      if (error instanceof EnvoiError) {
-        Logger.error(error.message);
-        process.exit(1);
-      } else {
-        Logger.errorWithContext('An unexpected error occurred:', error);
-        console.error('Full error:', error);
-        process.exit(1);
-      }
-    }
-  });
+Examples:
+  envoi exec                    # Uses default command from envoi.yml
+  envoi exec "node server.js" # Override with command line
+  envoi exec -- node server.js  # New -- separator syntax
+  envoi env
+  envoi exec "echo $DATABASE_URL" --verbose`;
 
-program
-  .command('env')
-  .description('Show loaded environment variables and their sources\n\nDisplays all resolved environment variables with their values and where they were loaded from.\nSource information shows: "environment" (existing env vars), "local:KEY" (.env files), "vault:PATH" (HashiCorp Vault), "openbao:PATH" (OpenBao), or "default".\nAlso shows the default command configuration if defined in envoi.yml.\n\nExamples:\n  envoi env\n  envoi env --config ./config/envoi.yml')
-  .option('-c, --config <path>', 'Path to envoi.yml configuration file (default: "./envoi.yml")', './envoi.yml')
-  .option('-v, --verbose', 'Enable verbose output showing variable resolution process', false)
-  .action(async (options) => {
-    Logger.setDebug(options.verbose);
-    Logger.debug('Starting env command');
-    try {
-      const config = await loadConfig(options.config);
-      
-      // Register providers based on configuration
-      registerProvidersFromConfig(config, options.verbose);
-      
-      // Filter out sources and variables for disabled providers
-      const filteredConfig = filterDisabledProviders(config);
-      
-      if (options.verbose) {
-        Logger.info(`Registered providers: ${providerRegistry.getRegisteredProviders().join(', ')}`);
-        Logger.info(`Filtered configuration to ${filteredConfig.variables.length} variables from ${config.variables.length} total`);
-      }
-      
-      const resolvedVariables = await resolveVariables(filteredConfig, options.verbose);
+program.name(packageJson.name).description(customDescription).version(packageJson.version);
 
-      Logger.header('envoi environment variables:');
-      Logger.blank();
+// Dynamically load and register all commands
+async function loadCommands(): Promise<void> {
+  try {
+    const registrations = await CommandRegistry.registerCommands(program);
 
-      if (resolvedVariables.length === 0) {
-        Logger.noVariables();
-        return;
-      }
-
-      const maxNameLength = Math.max(...resolvedVariables.map(v => v.name.length));
-      
-      resolvedVariables.forEach(variable => {
-        Logger.variable(variable.name, variable.value, variable.source, maxNameLength + 2);
+    if (process.env.DEBUG || process.env.VERBOSE) {
+      Logger.info(`[Boot] Loaded ${registrations.length} commands:`);
+      registrations.forEach((reg) => {
+        Logger.info(`[Boot]  - ${reg.command.command}: ${reg.command.description}`);
       });
-
-      // Show command configuration if it exists
-      if (config.command?.default) {
-        Logger.blank();
-        Logger.header('Default Command:');
-        Logger.blank();
-        
-        const commandInfo = config.command.description 
-          ? `${config.command.default} - ${config.command.description}`
-          : config.command.default;
-        
-        Logger.plain(`  ${commandInfo}`);
-      }
-    } catch (error) {
-      if (error instanceof EnvoiError) {
-        Logger.error(error.message);
-        process.exit(1);
-      } else {
-        Logger.errorWithContext('An unexpected error occurred:', error);
-        console.error('Full error:', error);
-        process.exit(1);
-      }
     }
-  });
+  } catch (error) {
+    console.error('[Boot] Failed to load commands:', error);
+    process.exit(1);
+  }
+}
 
-program.parse();
+// Load commands and start the CLI
+loadCommands()
+  .then(() => program.parse())
+  .catch((error) => {
+    Logger.error('[Boot] Failed to initialize CLI:', error);
+    process.exit(1);
+  });

--- a/src/providers/dynamic-registration.ts
+++ b/src/providers/dynamic-registration.ts
@@ -10,45 +10,45 @@ export function registerProvidersFromConfig(config: EnvoiConfig, verbose: boolea
   providerRegistry.clear();
   
   if (!config.providers) {
-    Logger.debug('No providers configuration found, using defaults');
+    Logger.debug('[DymanicResgistration] No providers configuration found, using defaults');
     // Register local provider as default if no providers config
     try {
       providerRegistry.register(ProviderFactory.create('local'));
-      Logger.debug('Registered default local provider');
+      Logger.debug('[DymanicResgistration] Registered default local provider');
     } catch (error) {
-      Logger.warn(`Failed to register default local provider: ${error}`);
+      Logger.warn(`[DymanicResgistration] Failed to register default local provider: ${error}`);
     }
     return;
   }
 
-  Logger.debug(`Found ${Object.keys(config.providers).length} provider configurations`);
+  Logger.debug(`[DymanicResgistration] Found ${Object.keys(config.providers).length} provider configurations`);
 
   // Register providers based on configuration
   for (const [name, providerConfig] of Object.entries(config.providers)) {
     if (!providerConfig.enabled) {
-      Logger.debug(`Provider '${name}' is disabled, skipping registration`);
+      Logger.debug(`[DymanicResgistration] Provider '${name}' is disabled, skipping registration`);
       continue;
     }
 
-    Logger.debug(`Registering provider '${name}' of type '${providerConfig.type}'`);
+    Logger.debug(`[DymanicResgistration] Registering provider '${name}' of type '${providerConfig.type}'`);
 
     try {
       const provider = ProviderFactory.create(providerConfig.type, providerConfig.config);
       providerRegistry.register(provider);
-      Logger.debug(`Successfully registered provider '${name}'`);
+      Logger.debug(`[DymanicResgistration] Successfully registered provider '${name}'`);
     } catch (error) {
       if (error instanceof ProviderError) {
-        Logger.warn(`Failed to register provider '${name}': ${error.message}`);
+        Logger.warn(`[DymanicResgistration] Failed to register provider '${name}': ${error.message}`);
       } else {
-        Logger.warn(`Failed to register provider '${name}': ${error}`);
+        Logger.warn(`[DymanicResgistration] Failed to register provider '${name}': ${error}`);
       }
     }
   }
 
   if (providerRegistry.isEmpty()) {
-    Logger.warn('No providers were successfully registered');
+    Logger.warn('[DymanicResgistration] No providers were successfully registered');
   } else {
     const registeredProviders = providerRegistry.getRegisteredProviders();
-    Logger.debug(`Registered providers: ${registeredProviders.join(', ')}`);
+    Logger.debug(`[DymanicResgistration] Registered providers: ${registeredProviders.join(', ')}`);
   }
 }

--- a/src/providers/dynamic-registration.ts
+++ b/src/providers/dynamic-registration.ts
@@ -1,0 +1,54 @@
+import { EnvoiConfig } from '../types';
+import { Logger } from '../utils/logger';
+import { ProviderError } from '../utils/errors';
+import { ProviderFactory } from './factory';
+import { providerRegistry } from './registry';
+
+export function registerProvidersFromConfig(config: EnvoiConfig, verbose: boolean): void {
+  Logger.setDebug(verbose);
+  // Clear existing providers
+  providerRegistry.clear();
+  
+  if (!config.providers) {
+    Logger.debug('No providers configuration found, using defaults');
+    // Register local provider as default if no providers config
+    try {
+      providerRegistry.register(ProviderFactory.create('local'));
+      Logger.debug('Registered default local provider');
+    } catch (error) {
+      Logger.warn(`Failed to register default local provider: ${error}`);
+    }
+    return;
+  }
+
+  Logger.debug(`Found ${Object.keys(config.providers).length} provider configurations`);
+
+  // Register providers based on configuration
+  for (const [name, providerConfig] of Object.entries(config.providers)) {
+    if (!providerConfig.enabled) {
+      Logger.debug(`Provider '${name}' is disabled, skipping registration`);
+      continue;
+    }
+
+    Logger.debug(`Registering provider '${name}' of type '${providerConfig.type}'`);
+
+    try {
+      const provider = ProviderFactory.create(providerConfig.type, providerConfig.config);
+      providerRegistry.register(provider);
+      Logger.debug(`Successfully registered provider '${name}'`);
+    } catch (error) {
+      if (error instanceof ProviderError) {
+        Logger.warn(`Failed to register provider '${name}': ${error.message}`);
+      } else {
+        Logger.warn(`Failed to register provider '${name}': ${error}`);
+      }
+    }
+  }
+
+  if (providerRegistry.isEmpty()) {
+    Logger.warn('No providers were successfully registered');
+  } else {
+    const registeredProviders = providerRegistry.getRegisteredProviders();
+    Logger.debug(`Registered providers: ${registeredProviders.join(', ')}`);
+  }
+}

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,0 +1,57 @@
+import { LocalProvider } from './local';
+import { Provider } from '../types';
+import { ProviderError } from '../utils/errors';
+import { VaultProvider } from './vault';
+import { substituteEnvVarsInObject } from '../utils/env-substitution';
+
+export class ProviderFactory {
+  private static providerClasses = {
+    local: LocalProvider,
+    vault: VaultProvider,
+  };
+
+  // Try to import OpenBaoProvider if available
+  private static getOpenBaoProvider(): typeof import('./openbao').OpenBaoProvider | null {
+    try {
+      const openbaoModule = require('./openbao');
+      return openbaoModule.OpenBaoProvider;
+    } catch {
+      return null;
+    }
+  }
+
+  static create(type: string, config?: any): Provider {
+    let ProviderClass: any;
+    
+    if (type === 'openbao') {
+      const OpenBaoProvider = this.getOpenBaoProvider();
+      if (!OpenBaoProvider) {
+        throw new ProviderError('OpenBao provider is not available');
+      }
+      ProviderClass = OpenBaoProvider;
+    } else {
+      ProviderClass = this.providerClasses[type as keyof typeof this.providerClasses];
+    }
+    
+    if (!ProviderClass) {
+      throw new ProviderError(`Unknown provider type: ${type}`);
+    }
+
+    // Substitute environment variables in config
+    const processedConfig = config ? substituteEnvVarsInObject(config) : undefined;
+    
+    try {
+      return new ProviderClass(processedConfig);
+    } catch (error) {
+      throw new ProviderError(`Failed to create ${type} provider: ${error}`);
+    }
+  }
+
+  static getAvailableProviders(): string[] {
+    const providers = Object.keys(this.providerClasses);
+    if (this.getOpenBaoProvider()) {
+      providers.push('openbao');
+    }
+    return providers;
+  }
+}

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -6,33 +6,39 @@ import { ProviderError } from '../utils/errors';
 
 export class LocalProvider implements Provider {
   name = 'local';
+  private configFile: string = '.env';
+
+  constructor(config?: any) {
+    if (config?.file) {
+      this.configFile = config.file;
+    }
+  }
 
   async resolve(source: VariableSource): Promise<string> {
     if (source.type !== 'local') {
       throw new ProviderError(`LocalProvider cannot handle source type: ${source.type}`);
     }
 
-    if (!source.file) {
-      throw new ProviderError('Local provider requires a "file" specification');
-    }
-
     if (!source.key) {
       throw new ProviderError('Local provider requires a "key" specification');
     }
 
+    // Use source.file if provided, otherwise use configured file
+    const filePath = source.file || this.configFile;
+
     try {
-      const envPath = path.resolve(source.file);
+      const envPath = path.resolve(filePath);
       const envExists = await fs.access(envPath).then(() => true).catch(() => false);
 
       if (!envExists) {
-        throw new ProviderError(`Environment file not found: ${source.file}`);
+        throw new ProviderError(`Environment file not found: ${filePath}`);
       }
 
       const envConfig = dotenv.parse(await fs.readFile(envPath, 'utf-8'));
       const value = envConfig[source.key];
 
       if (value === undefined) {
-        throw new ProviderError(`Key "${source.key}" not found in ${source.file}`);
+        throw new ProviderError(`Key "${source.key}" not found in ${filePath}`);
       }
 
       return value;
@@ -40,7 +46,7 @@ export class LocalProvider implements Provider {
       if (error instanceof ProviderError) {
         throw error;
       }
-      throw new ProviderError(`Failed to read from ${source.file}: ${error}`);
+      throw new ProviderError(`Failed to read from ${filePath}: ${error}`);
     }
   }
 }

--- a/src/providers/openbao.ts
+++ b/src/providers/openbao.ts
@@ -1,0 +1,95 @@
+import fetch from 'node-fetch';
+import { Provider, VariableSource } from '../types';
+import { ProviderError } from '../utils/errors';
+
+interface OpenBaoSecretData {
+  data: Record<string, any>;
+}
+
+interface OpenBaoResponse {
+  data: OpenBaoSecretData;
+}
+
+export class OpenBaoProvider implements Provider {
+  name = 'openbao';
+  private baseUrl: string;
+  private token: string;
+
+  constructor() {
+    this.baseUrl = process.env.OPENBAO_ADDR || 'http://127.0.0.1:8200';
+    this.token = process.env.OPENBAO_TOKEN || '';
+    
+    if (!this.token) {
+      throw new ProviderError(
+        'OPENBAO_TOKEN environment variable is required for OpenBao provider'
+      );
+    }
+  }
+
+  async resolve(source: VariableSource): Promise<string> {
+    if (source.type !== 'openbao') {
+      throw new ProviderError(`OpenBaoProvider cannot handle source type: ${source.type}`);
+    }
+
+    if (!source.path) {
+      throw new ProviderError('OpenBao provider requires a "path" specification');
+    }
+
+    if (!source.key) {
+      throw new ProviderError('OpenBao provider requires a "key" specification');
+    }
+
+    try {
+      const url = `${this.baseUrl}/v1/${source.path}`;
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'X-Vault-Token': this.token,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new ProviderError(
+          `OpenBao API request failed: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const result: OpenBaoResponse = await response.json() as OpenBaoResponse;
+      
+      if (!result || !result.data || !result.data.data) {
+        throw new ProviderError(`No data found at OpenBao path: ${source.path}`);
+      }
+
+      const value = result.data.data[source.key];
+      
+      if (value === undefined || value === null) {
+        throw new ProviderError(
+          `Key "${source.key}" not found in OpenBao secret at path: ${source.path}`
+        );
+      }
+
+      if (typeof value !== 'string') {
+        throw new ProviderError(
+          `Expected string value for key "${source.key}", but got ${typeof value}`
+        );
+      }
+
+      return value;
+    } catch (error) {
+      if (error instanceof ProviderError) {
+        throw error;
+      }
+      
+      if (error && typeof error === 'object' && 'message' in error) {
+        throw new ProviderError(
+          `Failed to read from OpenBao at ${source.path}: ${error.message}`
+        );
+      }
+      
+      throw new ProviderError(
+        `Failed to read from OpenBao at ${source.path}: ${error}`
+      );
+    }
+  }
+}

--- a/src/providers/openbao.ts
+++ b/src/providers/openbao.ts
@@ -1,6 +1,7 @@
-import fetch from 'node-fetch';
 import { Provider, VariableSource } from '../types';
+
 import { ProviderError } from '../utils/errors';
+import fetch from 'node-fetch';
 
 interface OpenBaoSecretData {
   data: Record<string, any>;
@@ -15,9 +16,9 @@ export class OpenBaoProvider implements Provider {
   private baseUrl: string;
   private token: string;
 
-  constructor() {
-    this.baseUrl = process.env.OPENBAO_ADDR || 'http://127.0.0.1:8200';
-    this.token = process.env.OPENBAO_TOKEN || '';
+  constructor(config?: any) {
+    this.baseUrl = config?.address || process.env.OPENBAO_ADDR || 'http://127.0.0.1:8200';
+    this.token = config?.token || process.env.OPENBAO_TOKEN || '';
     
     if (!this.token) {
       throw new ProviderError(

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -18,6 +18,18 @@ export class ProviderRegistry {
   has(name: string): boolean {
     return this.providers.has(name);
   }
+
+  clear(): void {
+    this.providers.clear();
+  }
+
+  isEmpty(): boolean {
+    return this.providers.size === 0;
+  }
+
+  getRegisteredProviders(): string[] {
+    return Array.from(this.providers.keys());
+  }
 }
 
 export const providerRegistry = new ProviderRegistry();

--- a/src/providers/vault.ts
+++ b/src/providers/vault.ts
@@ -11,12 +11,12 @@ export class VaultProvider implements Provider {
   name = 'vault';
   private client?: any;
 
-  constructor() {
-    this.initializeClient();
+  constructor(config?: any) {
+    this.initializeClient(config);
   }
 
-  private initializeClient(): void {
-    const token = process.env.VAULT_TOKEN;
+  private initializeClient(config?: any): void {
+    const token = config?.token || process.env.VAULT_TOKEN;
     if (!token) {
       throw new ProviderError(
         'VAULT_TOKEN environment variable is required for Vault provider'
@@ -32,7 +32,7 @@ export class VaultProvider implements Provider {
     // Use the default export or fallback to the main export
     const vault = (vaultModule as any).default || vaultModule;
     this.client = vault({
-      endpoint: process.env.VAULT_ADDR || 'http://127.0.0.1:8200',
+      endpoint: config?.address || process.env.VAULT_ADDR || 'http://127.0.0.1:8200',
       token: token,
     });
   }

--- a/src/providers/vault.ts
+++ b/src/providers/vault.ts
@@ -1,4 +1,9 @@
-import * as vaultModule from 'node-vault';
+// Note: node-vault is optional dependency
+try {
+  var vaultModule = require('node-vault');
+} catch (e) {
+  // Module not available
+}
 import { Provider, VariableSource } from '../types';
 import { ProviderError } from '../utils/errors';
 
@@ -15,6 +20,12 @@ export class VaultProvider implements Provider {
     if (!token) {
       throw new ProviderError(
         'VAULT_TOKEN environment variable is required for Vault provider'
+      );
+    }
+
+    if (!vaultModule) {
+      throw new ProviderError(
+        'Vault provider requires node-vault dependency. Install it with: npm install node-vault'
       );
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,28 +1,3 @@
-export interface VariableDefinition {
-  name: string;
-  required?: boolean | undefined;
-  default?: string | undefined;
-  description?: string | undefined;
-}
-
-export interface VariableSource {
-  type: 'local' | 'vault';
-  file?: string | undefined; // For local type
-  key?: string | undefined; // If not provided, uses variable name
-  path?: string | undefined; // For vault type
-}
-
-export interface CommandConfig {
-  default?: string | undefined;
-  description?: string | undefined;
-}
-
-export interface EnvoiConfig {
-  variables: VariableDefinition[];
-  sources?: Record<string, VariableSource> | undefined;
-  command?: CommandConfig | undefined;
-}
-
 export interface ResolvedVariable {
   name: string;
   value: string;
@@ -31,5 +6,15 @@ export interface ResolvedVariable {
 
 export interface Provider {
   name: string;
-  resolve(source: VariableSource): Promise<string>;
+  resolve(source: import('../config/schema').VariableSource): Promise<string>;
 }
+
+// Re-export types from schema to maintain consistency
+export type {
+  VariableDefinition,
+  VariableSource,
+  CommandConfig,
+  ProviderConfig,
+  ProvidersConfig,
+  EnvoiConfig,
+} from '../config/schema';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,19 @@ export interface Provider {
   resolve(source: import('../config/schema').VariableSource): Promise<string>;
 }
 
+export interface ProgramOption {
+  flags: string,
+  description?: string,
+  defaultValue?: string | boolean | string[],
+}
+
+export interface ProgramCommand {
+  command: string;
+  description: string;
+  options: ProgramOption[];
+  action: (...args: any[]) => void | Promise<void>;
+}
+
 // Re-export types from schema to maintain consistency
 export type {
   VariableDefinition,

--- a/src/utils/env-substitution.ts
+++ b/src/utils/env-substitution.ts
@@ -1,0 +1,39 @@
+import * as dotenv from 'dotenv';
+
+/**
+ * Environment variable substitution utility.
+ * Replaces ${VAR_NAME} patterns with values from process.env.
+ */
+export function substituteEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_match, varName) => {
+    const envValue = process.env[varName];
+    if (envValue === undefined) {
+      throw new Error(`Environment variable '${varName}' not found for substitution in: ${value}`);
+    }
+    return envValue;
+  });
+}
+
+/**
+ * Recursively substitute environment variables in an object.
+ */
+export function substituteEnvVarsInObject(obj: any): any {
+  dotenv.config();
+  if (typeof obj === 'string') {
+    return substituteEnvVars(obj);
+  }
+  
+  if (Array.isArray(obj)) {
+    return obj.map(item => substituteEnvVarsInObject(item));
+  }
+  
+  if (obj && typeof obj === 'object') {
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = substituteEnvVarsInObject(value);
+    }
+    return result;
+  }
+  
+  return obj;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,22 +16,22 @@ export class Logger {
   /**
    * Log informational message
    */
-  static info(message: string): void {
-    console.log(chalk.blue('ℹ') + ' ' + chalk.blue(message));
+  static info(message: string, ...optionalParams: unknown[]): void {
+    console.log(chalk.blue('ℹ') + ' ' + chalk.blue(message), ...optionalParams);
   }
 
   /**
    * Log warning message
    */
-  static warn(message: string): void {
-    console.log(chalk.yellow('⚠') + ' ' + chalk.yellow(message));
+  static warn(message: string, ...optionalParams: unknown[]): void {
+    console.log(chalk.yellow('⚠') + ' ' + chalk.yellow(message), ...optionalParams);
   }
 
   /**
    * Log error message
    */
-  static error(message: string): void {
-    console.error(chalk.red('❌') + ' ' + chalk.red(message));
+  static error(message: string, ...optionalParams: unknown[]): void {
+    console.error(chalk.red('❌') + ' ' + chalk.red(message), ...optionalParams);
   }
 
   /**
@@ -47,16 +47,16 @@ export class Logger {
   /**
    * Log success message
    */
-  static success(message: string): void {
-    console.log(chalk.green('✓') + ' ' + chalk.green(message));
+  static success(message: string, ...optionalParams: unknown[]): void {
+    console.log(chalk.green('✓') + ' ' + chalk.green(message), ...optionalParams);
   }
 
   /**
    * Log debug message (only shown when debug is enabled)
    */
-  static debug(message: string): void {
+  static debug(message: string, ...optionalParams: unknown[]): void {
     if (this.debugEnabled) {
-      console.log(chalk.dim('🐛') + ' ' + chalk.dim(message));
+      console.log(chalk.dim('🐛') + ' ' + chalk.dim(message), ...optionalParams);
     }
   }
 

--- a/src/utils/provider-filter.ts
+++ b/src/utils/provider-filter.ts
@@ -1,0 +1,41 @@
+import { EnvoiConfig } from '../types';
+import { providerRegistry } from '../providers/registry';
+
+/**
+ * Filter configuration to remove sources and variables that reference disabled providers
+ */
+export function filterDisabledProviders(config: EnvoiConfig): EnvoiConfig {
+  const filteredConfig: EnvoiConfig = {
+    variables: [],
+    providers: config.providers,
+    command: config.command,
+  };
+
+  // Get registered providers (only enabled ones)
+  const registeredProviders = providerRegistry.getRegisteredProviders();
+  const enabledProviderTypes = new Set(registeredProviders);
+
+  // Filter variables: only keep those that either don't require a source or use an enabled provider
+  filteredConfig.variables = config.variables.filter(variable => {
+    // If variable has a source configured, check if the provider type is enabled
+    if (config.sources && config.sources[variable.name]) {
+      const source = config.sources[variable.name];
+      return enabledProviderTypes.has(source.type);
+    }
+    // Keep variables without sources (they'll use defaults or environment)
+    return true;
+  });
+
+  // Filter sources: only keep those that use enabled providers
+  if (config.sources) {
+    const filteredSources: Record<string, any> = {};
+    for (const [variableName, source] of Object.entries(config.sources)) {
+      if (enabledProviderTypes.has(source.type)) {
+        filteredSources[variableName] = source;
+      }
+    }
+    filteredConfig.sources = filteredSources;
+  }
+
+  return filteredConfig;
+}


### PR DESCRIPTION
## Summary
- Migrate from HashiCorp Vault to OpenBao for secret management
- Add PostgreSQL backend for OpenBao storage
- Implement dynamic provider registration system
- Add provider filtering capabilities
- Update CLI structure with command pattern
- Add Docker Compose setup for local development
- Include comprehensive test coverage for OpenBao integration

## Technical Changes
- **OpenBao Provider**: New `OpenBaoProvider` class for OpenBao integration
- **Dynamic Registration**: System for enabling/disabling providers via configuration
- **Provider Filtering**: Filter out variables from disabled providers
- **Docker Setup**: PostgreSQL + OpenBao containerized development environment
- **CLI Refactor**: Restructured CLI with improved command pattern
- **Enhanced Logging**: Added colored logging system for better UX

## Test plan
- [ ] Run existing test suite to ensure backward compatibility
- [ ] Test OpenBao provider integration with local Docker setup
- [ ] Verify dynamic provider registration functionality
- [ ] Test provider filtering with disabled providers
- [ ] Validate Docker Compose setup works correctly
- [ ] Test CLI commands with new structure

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>