### PR TITLE
fix: map GitHub token to expected environment variable for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,6 @@ jobs:
     
     - name: Semantic Release
       env:
-        PERSONAL_GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npx semantic-release


### PR DESCRIPTION
## Summary
- Fix GITHUB_TOKEN environment variable mapping for semantic-release
- semantic-release expects GITHUB_TOKEN not PERSONAL_GITHUB_TOKEN
- This should resolve the ENOGHTOKEN error in release workflow

## Issue
The release workflow was failing with:
- ENOGHTOKEN No GitHub token specified
- EINVALIDNPMTOKEN Invalid npm token

## Solution
- Map PERSONAL_GITHUB_TOKEN to GITHUB_TOKEN environment variable
- semantic-release will now be able to authenticate with GitHub properly

## Test plan
- [ ] Release workflow should be able to authenticate with GitHub
- [ ] semantic-release should be able to push tags and create releases
- [ ] npm publishing should work (if NPM_TOKEN is properly configured)

🤖 Generated with [Claude Code](https://claude.ai/code)